### PR TITLE
Change from Rules to RulesSet and add a simple example

### DIFF
--- a/modsecurity/examples/simpleblock.go
+++ b/modsecurity/examples/simpleblock.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aledbf/blockade/modsecurity"
+)
+
+func main() {
+
+	modsec, err := modsecurity.NewModsecurity()
+	if err != nil {
+		panic(err)
+	}
+
+	modsec.SetServerLogCallback(func(msg string) {
+		log.Println(msg)
+	})
+
+	ruleset := modsec.NewRuleSet()
+	err = ruleset.AddFile("basic_rules.conf")
+	if err != nil {
+		panic(err)
+	}
+	transaction, err := ruleset.NewTransaction("127.0.0.1:12345", "10.10.10.0:80")
+	if err != nil {
+		panic(err)
+	}
+
+	err = transaction.ProcessUri("http://www.modsecurity.org/test?key1=value1&key2=value2&key3=value3", "GET", "1.!")
+	if err != nil {
+		panic(err)
+	}
+
+	err = transaction.AddRequestHeader([]byte("HEADER1"), []byte("XPTO123"))
+	if err != nil {
+		panic(err)
+	}
+
+	err = transaction.ProcessRequestHeaders()
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = transaction.ProcessLogging()
+
+	if err != nil {
+		panic(err)
+	}
+
+	shouldintervene := transaction.ShouldIntervene()
+	fmt.Printf("%t", shouldintervene)
+
+	transaction.Cleanup()
+}

--- a/modsecurity/go.mod
+++ b/modsecurity/go.mod
@@ -1,0 +1,3 @@
+module github.com/aledbf/blockade/modsecurity
+
+go 1.13

--- a/modsecurity/modsecurity.go
+++ b/modsecurity/modsecurity.go
@@ -22,7 +22,7 @@ package modsecurity
 
 #include "modsecurity/modsecurity.h"
 #include "modsecurity/transaction.h"
-#include "modsecurity/rules.h"
+#include "modsecurity/rules_set.h"
 */
 import "C"
 

--- a/modsecurity/rules.go
+++ b/modsecurity/rules.go
@@ -23,9 +23,9 @@ package modsecurity
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "modsecurity/rules.h"
+#include "modsecurity/rules_set.h"
 
-int msc_rules_add_file_bridge(Rules *rules, const char *file, char *error) {
+int msc_rules_add_file_bridge(RulesSet *rules, const char *file, char *error) {
 	const char *err = NULL;
 	int ret;
 
@@ -35,7 +35,7 @@ int msc_rules_add_file_bridge(Rules *rules, const char *file, char *error) {
     return ret;
 }
 
-int msc_rules_add_bridge(Rules *rules, const char *plain_rules, char *error) {
+int msc_rules_add_bridge(RulesSet *rules, const char *plain_rules, char *error) {
 	const char *err = NULL;
 	int ret;
 

--- a/modsecurity/transaction.go
+++ b/modsecurity/transaction.go
@@ -25,7 +25,7 @@ package modsecurity
 #include "modsecurity/modsecurity.h"
 #include "modsecurity/transaction.h"
 
-Transaction *msc_new_transaction_cgo(ModSecurity *ms, Rules *rules, long logCbData) {
+Transaction *msc_new_transaction_cgo(ModSecurity *ms, RulesSet *rules, long logCbData) {
     return msc_new_transaction(ms, rules, (void*)(intptr_t)logCbData);
 }
 */


### PR DESCRIPTION
This changes from Rules to RulesSet as per modsecurity commit: 

https://github.com/SpiderLabs/ModSecurity/commit/7495675d540b3b3ccce681773205a4fe34daeb64#diff-e2079590e07f5bc2472fa3a350aea02c

Also it adds a simple example.

Note that the intervention is not working yet (always false), need to figure out if this is a changed behavior from the library, some missing config into mod_security or something else.

Also need to add the process_response_header and other methods to the library, will do this in another issue.

Edit: intervention is working, just need to change the crs-setup.conf from pass to deny :) 